### PR TITLE
fix some usb bugs

### DIFF
--- a/os/hal/ports/RP/LLD/USBDv1/hal_usb_lld.c
+++ b/os/hal/ports/RP/LLD/USBDv1/hal_usb_lld.c
@@ -686,10 +686,10 @@ void usb_lld_init_endpoint(USBDriver *usbp, usbep_t ep) {
     epcp->in_state->hw_buf = (uint8_t*)&USB_DPSRAM->DATA[buf_offset];
     epcp->in_state->buf_size = buf_size;
 
-    EP_CTRL(ep).IN |= USB_EP_EN |
+    EP_CTRL(ep).IN = USB_EP_EN |
                       (epcp->ep_mode << USB_EP_TYPE_Pos) |
-                      buf_offset;
-    BUF_CTRL(ep).IN |= buf_ctrl;
+                      ((uint8_t*)epcp->in_state->hw_buf - (uint8_t*)USB_DPSRAM);
+    BUF_CTRL(ep).IN = buf_ctrl;
   }
 
   if (epcp->out_state) {
@@ -708,10 +708,10 @@ void usb_lld_init_endpoint(USBDriver *usbp, usbep_t ep) {
     epcp->out_state->hw_buf = (uint8_t*)&USB_DPSRAM->DATA[buf_offset];
     epcp->out_state->buf_size = buf_size;
 
-    EP_CTRL(ep).OUT |= USB_EP_EN |
+    EP_CTRL(ep).OUT = USB_EP_EN |
                        (epcp->ep_mode << USB_EP_TYPE_Pos) |
-                       buf_offset;
-    BUF_CTRL(ep).OUT |= buf_ctrl;
+                       ((uint8_t*)epcp->out_state->hw_buf - (uint8_t*)USB_DPSRAM);
+    BUF_CTRL(ep).OUT = buf_ctrl;
   }
 }
 

--- a/os/hal/ports/RP/LLD/USBDv1/hal_usb_lld.h
+++ b/os/hal/ports/RP/LLD/USBDv1/hal_usb_lld.h
@@ -50,12 +50,12 @@
 /**
  * @brief   Address ack handling
  */
-#define USB_SET_ADDRESS_ACK_HANDLING        USB_SET_ADDRESS_ACK_HW
+#define USB_SET_ADDRESS_ACK_HANDLING        USB_SET_ADDRESS_ACK_SW
 
 /**
  * @brief   This device requires the address change after the status packet.
  */
-#define USB_SET_ADDRESS_MODE                USB_EARLY_SET_ADDRESS
+#define USB_SET_ADDRESS_MODE                USB_LATE_SET_ADDRESS
 
 /*===========================================================================*/
 /* Driver data structures and types.                                         */


### PR DESCRIPTION
now it can enumerate:

```
[2709101.432838] usb 1-5.3: new full-speed USB device number 39 using xhci_hcd
[2709101.646510] usb 1-5.3: New USB device found, idVendor=0179, idProduct=0002, bcdDevice= 2.00
[2709101.646520] usb 1-5.3: New USB device strings: Mfr=1, Product=2, SerialNumber=3
[2709101.646524] usb 1-5.3: Product: ChTsy
[2709101.646526] usb 1-5.3: Manufacturer: NopeLab
[2709101.646529] usb 1-5.3: SerialNumber: 700
[2709101.679013] hid-generic 0003:0179:0002.154B: hiddev2,hidraw11: USB HID v1.10 Device [NopeLab ChTsy] on usb-0000:12:00.0-5.3/input0
```